### PR TITLE
TE-010 add MVC tests for order controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.berlin</groupId>
@@ -25,19 +25,32 @@
 	</properties>
 
 	<dependencies>
-	<!--	<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency> -->
+		<!--	<dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-security</artifactId>
+            </dependency> -->
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.1</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>
@@ -51,51 +64,36 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+			<artifactId>spring-boot-devtools</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
-			<scope>test</scope>
+			<groupId>com.sendgrid</groupId>
+			<artifactId>sendgrid-java</artifactId>
+			<version>4.2.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-			<version>2.0.4.RELEASE</version>
+			<groupId>commons-validator</groupId>
+			<artifactId>commons-validator</artifactId>
+			<version>1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.0</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path-assert</artifactId>
+			<version>2.2.0</version>
+			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>com.sendgrid</groupId>
-            <artifactId>sendgrid-java</artifactId>
-            <version>4.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
-        </dependency>
 
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/de/berlin/lostberlin/controller/OrderController.java
+++ b/src/main/java/de/berlin/lostberlin/controller/OrderController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+
 import java.util.List;
 
 @RestController
@@ -23,7 +24,7 @@ public class OrderController {
     }
 
     @GetMapping("/orders")
-    public List<Order> getOrders(@RequestParam (required=true, value = "business_id") String businessId){
+    public List<Order> getOrders(@RequestParam (required=true, value = "business_id") Long businessId) {
         return orderRepo.findAllByBusinessId(businessId);
     }
 
@@ -33,7 +34,7 @@ public class OrderController {
                 ||order.getName().equals("")
                 ||!EmailValidator.getInstance().isValid(order.getEmail())
         ){
-            return "Bad parameters";
+            return "Bad request";
         }
         Order result = orderRepo.save(order);
         if (result!=null){
@@ -60,6 +61,7 @@ public class OrderController {
     public Order updateOrderStatus(@PathVariable (value="order_number") String orderNr, @Valid @RequestBody Order orderProfile){
     Order order = orderRepo.findById(orderNr)
             .orElseThrow(() -> new ResourceNotFoundException("Order", "order_number", orderNr));
+    order.setBusinessId(orderProfile.getBusinessId());
     order.setStatus(orderProfile.getStatus());
 
         return orderRepo.save(order);

--- a/src/main/java/de/berlin/lostberlin/model/Order.java
+++ b/src/main/java/de/berlin/lostberlin/model/Order.java
@@ -21,9 +21,7 @@ public class Order {
     @GenericGenerator(
             name = "order_num",
             strategy = "de.berlin.lostberlin.model.DatePrefixedSequenceIdGenerator",
-            parameters = {@Parameter(name = DatePrefixedSequenceIdGenerator.INCREMENT_PARAM, value = "50")}
-    )
-    @NotBlank
+            parameters = {@Parameter(name = DatePrefixedSequenceIdGenerator.INCREMENT_PARAM, value = "50")})
     private String orderNr;
     private Long[] chosenBusinessIds;
     private Long businessId;

--- a/src/main/java/de/berlin/lostberlin/repository/OrderRepository.java
+++ b/src/main/java/de/berlin/lostberlin/repository/OrderRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, String> {
-    List<Order> findAllByBusinessId (String businessId);
+    List<Order> findAllByBusinessId (Long businessId);
 }
 

--- a/src/test/java/de/berlin/lostberlin/controller/OrderControllerIntegrationTest.java
+++ b/src/test/java/de/berlin/lostberlin/controller/OrderControllerIntegrationTest.java
@@ -1,0 +1,150 @@
+package de.berlin.lostberlin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.berlin.lostberlin.model.Order;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class OrderControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Test
+    public void test_get_all_orders_success() throws Exception {
+        mvc.perform(get("/orders/all")
+        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").exists())
+                .andExpect(jsonPath("$[0].email").exists())
+                .andExpect(jsonPath("$[1].name").exists())
+                .andExpect(jsonPath("$[1].email").exists())
+                .andDo(print());
+    }
+
+    @Test
+    public void test_get_orders_success() throws Exception {
+        mvc.perform(get("/orders/")
+        .contentType(MediaType.APPLICATION_JSON)
+        .param("business_id","1"))
+                .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE));
+    }
+
+    @Test
+    public void test_create_order_success() throws Exception {
+        Order order = mockOrder();
+        String json = mapper.writeValueAsString(order);
+
+        mvc.perform(post("/orders")
+        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Success"));
+    }
+
+    @Test
+    public void test_create_order_bad_request() throws Exception {
+        Order order = mockOrderMissingFields();
+        String json = mapper.writeValueAsString(order);
+
+        mvc.perform(post("/orders")
+        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void test_get_by_order_nr_success() throws Exception {
+        mvc.perform(get("/orders/{order_number}", "2018-10_00052"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(jsonPath("$.name").exists())
+                .andExpect(jsonPath("$.email").exists());
+    }
+
+    @Test
+    public void test_get_by_order_nr_not_found() throws Exception {
+        mvc.perform(get("/orders/{order_number}", "2018-10_00000")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+
+    @Test
+    public void test_update_order_status_success() throws Exception {
+        Order order = mockOrderUpdate();
+        String json = mapper.writeValueAsString(order);
+
+        mvc.perform(put("/orders/{order_number}/status", "2018-10_00102")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void test_update_order_status_not_found() throws Exception {
+        Order order = mockOrderUpdate();
+        String json = mapper.writeValueAsString(order);
+
+        mvc.perform(put("/orders/{order_number}/status", "2018-10_00000")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void test_update_order_status_bad_request() throws Exception {
+        Order order = mockOrderMissingFields();
+        String json = mapper.writeValueAsString(order);
+
+        mvc.perform(put("/orders/{order_number}/status", "2018-10_00000")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    private Order mockOrder() {
+        Order order = new Order();
+        Long[] chosenBusinessIds ={4L,5L,6L};
+        order.setName("Maxim");
+        order.setChosenBusinessIds(chosenBusinessIds);
+        order.setEmail("animamedianatura@gmx.com");
+        order.setPhone("017628834523");
+        order.setDescription("Hi, I'm Max, the tourist!");
+        return order;
+    }
+
+    private Order mockOrderMissingFields() {
+        Order order = new Order();
+        order.setName("Maxim");
+        order.setPhone("017628834523");
+        return order;
+    }
+
+    private Order mockOrderUpdate(){
+        Order order = new Order();
+        order.setName("Alena");
+        order.setEmail("aoneko@gmx.de");
+        order.setBusinessId(2L);
+        order.setStatus("confirmed");
+        return order;
+    }
+}

--- a/src/test/java/de/berlin/lostberlin/controller/OrderControllerMVCTest.java
+++ b/src/test/java/de/berlin/lostberlin/controller/OrderControllerMVCTest.java
@@ -1,0 +1,219 @@
+package de.berlin.lostberlin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.berlin.lostberlin.exception.ResourceNotFoundException;
+import de.berlin.lostberlin.model.Order;
+import de.berlin.lostberlin.repository.OrderRepository;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+/*
+In order to run MVC tests I had to comment out the annotation @EnableJpaAuditing in the main class.
+Unfortunately I didn't manage to fix it in a more appropriate way. Advises and hints will be highly appreciated!
+ */
+@RunWith(SpringRunner.class)
+@WebMvcTest(OrderController.class)
+public class OrderControllerMVCTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @MockBean
+    OrderRepository orderRepo;
+
+    @MockBean
+    private OrderController orderController;
+
+    @Test
+    public void test_get_all_orders_success() throws Exception {
+        Order order = mockOrder();
+        List<Order> allOrders = singletonList(order);
+        given(this.orderController.getAllOrders()).willReturn(allOrders);
+
+        mvc.perform(get("/orders/all")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value(order.getName()))
+                .andExpect(jsonPath("$[0].email").value(order.getEmail()))
+                .andDo(print());
+        verify(orderController, times(1)).getAllOrders();
+        verifyNoMoreInteractions(orderController);
+    }
+
+    @Test
+    public void test_get_orders_success() throws Exception {
+        Order order = mockOrderUpdate();
+        List<Order> orderListById = singletonList(order);
+        Long[] chosenBusinessIds ={4L,5L,6L};
+        given(this.orderController.getOrders(2L)).willReturn(orderListById);
+        mvc.perform(get("/orders/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("business_id","2"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE));
+    }
+
+    @Test
+    public void test_create_order_success() throws Exception {
+        Order order = mockOrder();
+        String json = mapper.writeValueAsString(order);
+        given(this.orderController.createOrder(order)).willReturn(json);
+
+        mvc.perform(post("/orders")
+                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .content(json))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void test_create_order_bad_request() throws Exception {
+        Order orderShort = mockOrderMissingFields();
+        String json = mapper.writeValueAsString(orderShort);
+        given(this.orderController.createOrder(orderShort)).willReturn(null);
+
+        mvc.perform(post("/orders")
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Ignore // Probably it's just a very wrong test, but I'll leave it anyways. Is there any better way to test this?
+    @Test
+        public void test_create_order_failed_to_save() throws Exception {
+            Order order = mockOrder();
+            String json = mapper.writeValueAsString(order);
+            Order result = orderRepo.save(order);
+            given(this.orderRepo.save(order)).willReturn(null);
+
+
+            mvc.perform(post("/orders")
+                    .contentType(MediaType.APPLICATION_JSON_UTF8)
+                    .content(json))
+                    .andExpect(content().string("Failed to save order "+order.getOrderNr()));
+        }
+
+    @Test
+    public void test_get_by_order_nr_success() throws Exception {
+        Order order = mockOrderWithNr();
+        String json = mapper.writeValueAsString(order);
+        when(this.orderController.getByOrderNr("2018-10_00052")).thenReturn(order);
+
+        mvc.perform(get("/orders/{order_number}", "2018-10_00052")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(jsonPath("$.name").value(order.getName()))
+                .andExpect(jsonPath("$.email").value(order.getEmail()));
+    }
+
+    @Test
+    public void test_get_by_order_nr_not_found() throws Exception {
+        Order order = mockOrderWithNr();
+        String json = mapper.writeValueAsString(order);
+        when(this.orderController.getByOrderNr("2018-10_00000")).thenThrow(new ResourceNotFoundException("Order", "order_number", "2018-10_00000"));
+
+        mvc.perform(get("/orders/{order_number}", "2018-10_00000")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+
+    @Test
+    public void test_update_order_status_success() throws Exception {
+        Order order = mockOrderUpdate();
+        String json = mapper.writeValueAsString(order);
+        when(this.orderController.updateOrderStatus(order.getOrderNr(), order)).thenReturn(order);
+        mvc.perform(put("/orders/{order_number}/status", order.getOrderNr())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk());
+    }
+
+    @Ignore //SAme problem here as in the BusinessControllerMVCTest (test_update_business_not_found())
+    @Test
+    public void test_update_order_status_not_found() throws Exception {
+        Order order = mockOrderUpdate();
+        String json = mapper.writeValueAsString(order);
+        when(this.orderController.updateOrderStatus("2018-10_00000", order)).thenThrow(new ResourceNotFoundException("Order", "order_number", "2018-10_00000"));
+        mvc.perform(put("/orders/{order_number}/status", "2018-10_00000")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void test_update_order_status_bad_request() throws Exception {
+        Order order = mockOrderMissingFields();
+        String json = mapper.writeValueAsString(order);
+
+        mvc.perform(put("/orders/{order_number}/status", "2018-10_00000")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    private Order mockOrder() {
+        Order order = new Order();
+        Long[] chosenBusinessIds ={4L,5L,6L};
+        order.setName("Maxim");
+        order.setChosenBusinessIds(chosenBusinessIds);
+        order.setEmail("animamedianatura@gmx.com");
+        order.setPhone("017628834523");
+        order.setDescription("Hi, I'm Max, the tourist!");
+        return order;
+    }
+
+    private Order mockOrderWithNr() {
+        Order order = new Order();
+        Long[] chosenBusinessIds = {4L, 5L, 6L};
+        order.setOrderNr("2018-10_00052");
+        order.setName("Maxim");
+        order.setChosenBusinessIds(chosenBusinessIds);
+        order.setEmail("animamedianatura@gmx.com");
+        order.setPhone("017628834523");
+        order.setDescription("Hi, I'm Max, the tourist!");
+        return order;
+    }
+
+    private Order mockOrderMissingFields() {
+        Order order = new Order();
+        order.setName("Maxim");
+        order.setPhone("017628834523");
+        return order;
+    }
+
+    private Order mockOrderUpdate(){
+        Order order = new Order();
+        order.setOrderNr("2018-10_00102");
+        order.setName("Alena");
+        order.setEmail("aoneko@gmx.de");
+        order.setBusinessId(2L);
+        order.setStatus("confirmed");
+        return order;
+    }
+}


### PR DESCRIPTION
Fixes #23

Open issues: 

1. Same issue as in TE-009: In order to run MVC tests I had to comment out the annotation @EnableJpaAuditing in the main class.
Unfortunately I didn't manage to fix it in a more appropriate way. Advises and hints will be highly appreciated!

2. Same issuer as in TE-009: test_update_order_status_not_found() in OrderControllerMockMvcTest keeps failing. Any idea why?

3. Added a bit ugly test_create_order_failed_to_save(), can't think of a better alternative right now. All suggestions are welcome))